### PR TITLE
xml2js vulnerability fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "csv": "^6.2.2",
     "entities": "^4.4.0",
     "mocha": "^10.1.0",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "nock": "^13.2.9"


### PR DESCRIPTION
Fix for a dependency vulnerability
```
# npm audit report

xml2js  <0.5.0
Severity: moderate
xml2js is vulnerable to prototype pollution - https://github.com/advisories/GHSA-776f-qx25-q3cc
```