### PR TITLE
remove k param in getLocation 

### DIFF
--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -319,9 +319,6 @@ function getLocations(options, callback) {
   options = options === callback ? undefined : options;
 
   var query = helper.setQuery(mapping.commands.locations, options);
-  // if (!query.k && this.config.key && !options.allLocations) {
-  //   query.k = this.config.key;
-  // }
   return api.call(this, paths.locations, callback, query, options);
 }
 

--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -319,9 +319,9 @@ function getLocations(options, callback) {
   options = options === callback ? undefined : options;
 
   var query = helper.setQuery(mapping.commands.locations, options);
-  if (!query.k && this.config.key && !options.allLocations) {
-    query.k = this.config.key;
-  }
+  // if (!query.k && this.config.key && !options.allLocations) {
+  //   query.k = this.config.key;
+  // }
   return api.call(this, paths.locations, callback, query, options);
 }
 


### PR DESCRIPTION
k param is no longer supported for passing API key. Remove k param in getLocation() as it should be passed in X-WPT-API-KEY header only.