### PR TITLE
AZD173229

### DIFF
--- a/lib/webpagetest.js
+++ b/lib/webpagetest.js
@@ -16,8 +16,7 @@ var http = require("http"),
   mapping = require("./mapping");
 
 var reSpace = /\s/,
-  reConnectivity =
-    /^(?:Cable|DSL|3GSlow|3G|3GFast|4G|LTE|Edge|2G|Dial|FIOS|Native|custom)$/,
+  reConnectivity = /^(?:Cable|DSL|3GSlow|3G|3GFast|4G|LTE|Edge|2G|Dial|FIOS|Native|custom)$/,
   reHTMLOutput = /<h\d[^<]*>([^<]+)<\/h\d>/; // for H3 on cancelTest.php
 
 var paths = {
@@ -92,7 +91,7 @@ function get(config, pathname, proxy, agent, callback, encoding) {
   }
 
   if (encoding !== "binary") {
-    options.headers["X-WPT-API-KEY"] = this.config.key;
+    options.headers["X-WPT-API-KEY"] = this.config.key ?? "";
     options.headers["accept-encoding"] = "gzip,deflate";
     options.headers["User-Agent"] = "WebpagetestNodeWrapper/v0.6.0";
   }
@@ -108,9 +107,7 @@ function get(config, pathname, proxy, agent, callback, encoding) {
         statusCode = res.statusCode;
 
       if (statusCode !== 200) {
-        callback(
-          new helper.WPTAPIError(statusCode, http.STATUS_CODES[statusCode])
-        );
+        callback(new helper.WPTAPIError(statusCode, http.STATUS_CODES[statusCode]));
       } else {
         data = [];
         length = 0;
@@ -191,6 +188,9 @@ function api(pathname, callback, query, options) {
     query: query,
   });
 
+  config.key = query.k ?? this.config.key;
+  delete query.k;
+
   if (options.dryRun) {
     // dry run: return the API url (string) only
     if (typeof callback === "function") {
@@ -210,10 +210,7 @@ function api(pathname, callback, query, options) {
             if (options.parser) {
               // async parser
               if (options.parser.async) {
-                return options.parser(
-                  data,
-                  asyncParserCallback.bind(callback, options)
-                );
+                return options.parser(data, asyncParserCallback.bind(callback, options));
               } else {
                 data = options.parser(data);
               }
@@ -223,10 +220,7 @@ function api(pathname, callback, query, options) {
               } else if (info.type === "application/json") {
                 data = JSON.parse(data);
               } else if (info.type === "text/xml") {
-                return helper.xmlToObj(
-                  data,
-                  asyncParserCallback.bind(callback, options)
-                );
+                return helper.xmlToObj(data, asyncParserCallback.bind(callback, options));
               } else if (info.type === "text/html") {
                 data = { result: (reHTMLOutput.exec(data) || [])[1] };
               } else if (info.type === "text/plain") {
@@ -255,10 +249,8 @@ function setFilename(input, options, doNotDefault) {
   options = options || {};
 
   // set run and cached with or without defaults
-  run =
-    parseInt(options.run || options.r, 10) || (doNotDefault ? undefined : 1);
-  cached =
-    options.repeatView || options.cached || options.c ? filenames.cached : "";
+  run = parseInt(options.run || options.r, 10) || (doNotDefault ? undefined : 1);
+  cached = options.repeatView || options.cached || options.c ? filenames.cached : "";
   // when falsy, check set default accordingly
   if (doNotDefault && !cached) {
     cached = ["repeatView", "cached", "c"].some(function (key) {
@@ -480,21 +472,12 @@ function runTest(what, options, callback) {
   if (options.pollResults && !options.dryRun) {
     options.pollResults = parseInt(options.pollResults * 1000, 10) || 5000;
 
-    return api.call(
-      this,
-      paths.test,
-      testCallback.bind(this, poll),
-      query,
-      options
-    );
+    return api.call(this, paths.test, testCallback.bind(this, poll), query, options);
   }
 
   // wait results
   if (options.waitResults && !options.dryRun) {
-    options.waitResults = helper.localhost(
-      options.waitResults,
-      WebPageTest.defaultWaitResultsPort
-    );
+    options.waitResults = helper.localhost(options.waitResults, WebPageTest.defaultWaitResultsPort);
 
     listen = listener.bind(this);
 
@@ -506,14 +489,7 @@ function runTest(what, options, callback) {
         res.end();
 
         if (uri.pathname === "/testdone" && uri.query.id === testId) {
-          server.close(
-            getTestResults.bind(
-              this,
-              uri.query.id,
-              resultsOptions,
-              resultsCallback
-            )
-          );
+          server.close(getTestResults.bind(this, uri.query.id, resultsOptions, resultsCallback));
         }
       }.bind(this)
     );
@@ -826,11 +802,9 @@ function getWaterfallImage(id, options, callback) {
 
   callback = callback || options;
   options = options === callback ? {} : options;
-  (query = setFilename({ test: id }, options)),
-    (options.encoding = options.encoding || "binary");
+  (query = setFilename({ test: id }, options)), (options.encoding = options.encoding || "binary");
   options.dataURI = options.dataURI || options.uri || options.u;
-  options.parser =
-    options.parser || (options.dataURI ? helper.dataURI : undefined);
+  options.parser = options.parser || (options.dataURI ? helper.dataURI : undefined);
   options.args = options.args || {
     type: "image/png",
     encoding: options.dataURI ? "utf8" : options.encoding,
@@ -856,8 +830,7 @@ function getScreenshotImage(id, options, callback) {
   options = options === callback ? {} : options;
   options.encoding = options.encoding || "binary";
   options.dataURI = options.dataURI || options.uri || options.u;
-  options.parser =
-    options.parser || (options.dataURI ? helper.dataURI : undefined);
+  options.parser = options.parser || (options.dataURI ? helper.dataURI : undefined);
 
   if (options.startRender || options.render || options.n) {
     filename = filenames.screenshotStartRender;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpagetest",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "WebPageTest API wrapper for NodeJS",
   "author": "WebPageTest <github@WebPageTest.com> (http://github.com/WebPageTest)",
   "homepage": "http://github.com/WebPageTest/webpagetest-api",


### PR DESCRIPTION
Caught a bug when user runs the test using cmd line interface, the wrapper passes the key with the query params. So here a fix for that.

Now, the key will be passed only with the headers.