### PR TITLE
Fixes file saving in `formatData`.

### DIFF
--- a/bin/webpagetest
+++ b/bin/webpagetest
@@ -59,13 +59,13 @@ var formatData = function(err, data, info) {
   }
 
   if (file) {
-    fs.writeFile(file, dataStr, encoding, function writeFile(err) {
+    fs.writeFile(file, (dataStr || data), encoding, function writeFile(err) {
       if (err) {
         output(err.message, 1);
       }
     });
   } else {
-    output(dataStr, err ? 1 : 0);
+    output((dataStr || data), err ? 1 : 0);
   }
 
   return data;


### PR DESCRIPTION
Previously, `formatData`  did not correctly handle cases when the returned content was binary in nature but was not a `Buffer` instance. This led to bugs such as failures when running:

`npx webpagetest waterfall <test_id> -o out.png -k <key>`

I'm not sure this patch is 100% correct, as the tests require Docker and that isn't running on my current device.

Fixes #192 